### PR TITLE
add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# The .dockerignore file excludes files from the container build process.
+#
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+# Exclude Git files
+.git
+.github
+.gitignore
+
+# Exclude Python cache files
+__pycache__
+.mypy_cache
+.pytest_cache
+.ruff_cache
+
+# Exclude Python virtual environment
+/venv


### PR DESCRIPTION
This will decrease size of cog by almost 1 GB

74M     ./repositories/stable-diffusion-stability-ai/.git
7.3M    ./repositories/BLIP/.git
43M     ./repositories/generative-models/.git
18M     ./repositories/CodeFormer/.git
452K    ./repositories/k-diffusion/.git
42M     ./.git
1.4M    ./extensions/multidiffusion-upscaler-for-automatic1111/.git
19M     ./extensions/sd-webui-controlnet/.git
523M    ./models/Lora/.git