### PR TITLE
Add seamless tiling feature

### DIFF
--- a/modules/debugging/debug_image.py
+++ b/modules/debugging/debug_image.py
@@ -1,0 +1,128 @@
+import os
+import platform
+import shutil
+from cog import Path
+from datetime import datetime
+from PIL import Image, ImageDraw, ImageFont
+from modules.tiling.img_utils import expand_canvas_tiling
+
+def save_output_img(pil_img, filename, info_text="", add_debug_info=True):
+    filepath = Path(filename) ## NOTE this is a cog.Path!!
+
+    ## make a copy of the image.
+    img_copy = pil_img.copy()
+
+    if info_text:
+        img_copy = burn_text_into_image(img_copy, info_text)
+
+    if add_debug_info:
+        img_copy = draw_debug_info_into_img(img_copy)
+
+    img_copy.save(filepath)
+
+    return filepath
+
+def burn_text_into_image(pil_img, text_str, pos_x=50, pos_y=50, font_size=22, font_name='arial.ttf'):
+    """
+    make font size resolution independent, based on image of 1024x1024
+    """
+    width, height = pil_img.size
+
+    ## lets just base it on the width of the image for now.
+    font_size = calc_relative(width, font_size)
+
+    draw = ImageDraw.Draw(pil_img, 'RGBA')
+
+    ## replace the font_name in the case we're on linux as we have to
+    ## pass a full path to the font file.
+    if platform.system()=='Linux':
+        font_name = '/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf'
+    font = ImageFont.truetype(font_name, size=font_size)
+    ## now lets make these positions relative.
+    text_pos_x = calc_relative(width, pos_x)
+    text_pos_y = calc_relative(width, pos_y)
+    text_position = (text_pos_x, text_pos_y)
+    text_color = 'rgb(255, 255, 255)'
+
+    ## draw a black backdrop to make text more visible
+    expand_size = calc_relative(width, 10)
+    draw_text_backdrop(text_str, draw, font, text_position, expand=expand_size)
+
+    ## now draw the text onto the image
+    draw.text(text_position, text_str, fill=text_color, font=font)
+
+    return pil_img
+
+def draw_text_backdrop(text_str, draw_obj, font_obj, pos, expand=10):
+    text_pos_x, text_pos_y = pos
+    # Determine the size of the text
+    bbox_x1, bbox_y1, bbox_x2, bbox_y2 = font_obj.getbbox(text_str)
+    bbox_x1 += text_pos_x - expand
+    bbox_y1 += text_pos_y - expand
+    bbox_x2 += text_pos_x + expand
+    bbox_y2 += text_pos_y + expand
+    text_bbox = (bbox_x1, bbox_y1, bbox_x2, bbox_y2)
+    # Draw the semi-transparent rectangle
+    draw_obj.rectangle(text_bbox, fill=(0, 0, 0, 128))  # 128 out of 255 for 50% opacity
+
+
+def draw_border(img, color='red', offset=1, thickness=1, darken=True):
+    draw = ImageDraw.Draw(img, 'RGBA')
+    width, height = img.size
+
+    ## if darken is turned on, we draw a dark rectangle in the middle of the border.
+    if darken:
+        draw.rectangle([(offset, offset), (width - offset, height - offset)],
+                       fill=(0, 0, 0, 128))  # 128 out of 255 for 50% opacity
+
+    ## now draw the border and return the image
+    # Draw multiple rectangles for thicker borders
+    for i in range(thickness):
+        draw.rectangle([(offset - i, offset - i), (width - offset - i, height - offset - i)], outline=color)
+
+    return img
+
+
+def calc_relative(width, abs_value):
+    """
+    function can be used to calculate any kind of relative sizes,
+    pixel offsets or font sizes
+    uses 1024 as the guidance size, and will increase or decrease
+    the relative size according to the provided width of the image.
+    """
+    scale_ratio = float(width) / 1024.0
+    relative_value= int(abs_value * scale_ratio)
+    return relative_value
+
+def debug_tiling_image(img):
+    debug_img = img.copy()
+    border_offset = calc_relative(debug_img.width, 100)
+    thickness = calc_relative(debug_img.width, 5)
+    draw_border(debug_img, color='black', offset=border_offset, thickness=thickness)
+    ## first lets make these images tile..
+    border_size = calc_relative(debug_img.width, 256)
+    tiling_img = expand_canvas_tiling(debug_img, darken=False)
+    return tiling_img
+
+def draw_debug_info_into_img(img):
+    width, height = img.size
+    img = burn_text_into_image(img, f'res: {width}x{height}px', pos_y=100)
+    return img
+
+def move_files_to_timestamped_subdirectory(source_directory):
+    # Get the current date and time formatted as YYYY-MM-DD_HH-MM-SS
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    # Create a new directory name with this timestamp
+    destination_directory = os.path.join(source_directory, timestamp)
+
+    # Create the directory if it does not exist
+    if not os.path.exists(destination_directory):
+        os.makedirs(destination_directory)
+
+    # List all files in the source directory
+    files = [f for f in os.listdir(source_directory) if os.path.isfile(os.path.join(source_directory, f))]
+
+    # Move each file to the new directory
+    for file in files:
+        shutil.move(os.path.join(source_directory, file), os.path.join(destination_directory, file))
+

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1397,6 +1397,8 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
         if image_mask is not None:
             # image_mask is passed in as RGBA by Gradio to support alpha masks,
             # but we still want to support binary masks.
+            if isinstance(image_mask, np.ndarray):
+                image_mask = Image.fromarray(image_mask) ## mega hack, make sure mask is a Pil image..
             image_mask = create_binary_mask(image_mask)
 
             if self.inpainting_mask_invert:

--- a/modules/tiling/img_utils.py
+++ b/modules/tiling/img_utils.py
@@ -1,0 +1,246 @@
+import base64
+import numpy as np
+from io import BytesIO
+from PIL import ImageOps, ImageEnhance, Image, ImageDraw, ImageFilter
+
+def add_border(img, border_size):
+    img = img.copy()
+    # Define the border size: (left, top, right, bottom)
+    border = (border_size, border_size, border_size, border_size)
+
+    # Create a new image with the border
+    # The expand argument in the border method adds the border on the outside of the image
+    bordered_img = ImageOps.expand(img, border=border, fill='black')
+
+    return bordered_img
+
+def crop_corner(img, crop_size, corner='bottom_right', darken=False):
+    # Open the original image
+    img = img.copy()
+    width, height = img.size
+
+    # Initialize coordinates
+    left, top, right, bottom = 0, 0, 0, 0
+
+    if corner == 'bottom_right':
+        left = width - crop_size
+        top = height - crop_size
+        right = width
+        bottom = height
+    elif corner == 'bottom_left':
+        left = 0
+        top = height - crop_size
+        right = crop_size
+        bottom = height
+    elif corner == 'top_right':
+        left = width - crop_size
+        top = 0
+        right = width
+        bottom = crop_size
+    elif corner == 'top_left':
+        left = 0
+        top = 0
+        right = crop_size
+        bottom = crop_size
+    else:
+        raise ValueError("Invalid corner. Choose from 'bottom_right', 'bottom_left', 'top_right', or 'top_left'.")
+
+    # Crop the image
+    cropped_img = img.crop((left, top, right, bottom))
+
+    if darken:
+        cropped_img = darken_image(cropped_img, 0.8)
+
+    return cropped_img
+
+def crop_side(img, crop_size, side, darken=False):
+    # Open the original image
+    img = img.copy()
+    width, height = img.size
+
+    # Initialize coordinates
+    left, top, right, bottom = 0, 0, width, height
+
+    if side == 'left':
+        right = crop_size
+    elif side == 'right':
+        left = width - crop_size
+    elif side == 'bottom':
+        top = height - crop_size
+    elif side == 'top':
+        bottom = crop_size
+    else:
+        raise ValueError("Invalid side. Choose from 'left', 'right', 'bottom', or 'top'.")
+
+    # Crop the image
+    cropped_img = img.crop((left, top, right, bottom))
+
+    if darken:
+        cropped_img = darken_image(cropped_img, 0.4)
+
+    return cropped_img
+
+def darken_image(img, factor=0.5):
+    # Create a brightness enhancer
+    enhancer = ImageEnhance.Brightness(img)
+
+    # Apply the enhancer with the given factor (0.5 to darken the image by 50%)
+    darkened_img = enhancer.enhance(factor)
+
+    return darkened_img
+
+def calculate_border_size(img, border_pct=5, mode='scaleup'):
+    """
+    ** function assumes square image **
+    mode can be either 'scaleup' or 'cropback'
+    - scale up calculates border size based on percentage of current image
+    - crop back calculates the border size based on a pre-expanded image,
+      thus will give us the border size we want to crop back from.
+    """
+    if isinstance(img, bytes):
+        img = convert_binary_img_to_pil(img)
+
+    width, height = img.size
+    border_size = 0 ## init to 0
+    if mode=='scaleup':
+        border_size = int(width * (border_pct / 100.0))
+    elif mode=='cropback':
+        border_size = int(width * (border_pct / (100.0 + border_pct + border_pct)))
+
+    return border_size
+
+def expand_canvas_tiling(img, div=8, darken=True):
+    width, height = img.size
+    org_size = width
+    border_size = int(org_size / div)
+
+    ## first add a black border around the image to expand the canvas
+    expanded_img = add_border(img, border_size)
+
+    ## now crop the bottom right, which will become the top left
+    tl_img = crop_corner(img, border_size, corner='bottom_right', darken=darken)
+    tl_x = 0
+    tl_y = 0
+    ## and the top left which will be place on the bottom right
+    br_img = crop_corner(img, border_size, corner='top_left', darken=darken)
+    br_x = org_size + border_size
+    br_y = org_size + border_size
+    ## and the bottom left which will be placed to the top right
+    tr_img = crop_corner(img, border_size, corner='bottom_left', darken=darken)
+    tr_x = org_size + border_size
+    tr_y = 0
+    ## and the top right which will be placed to the bottom left
+    bl_img = crop_corner(img, border_size, corner='top_right', darken=darken)
+    bl_x = 0
+    bl_y = org_size + border_size
+
+    ## now crop the sides.
+    left_img = crop_side(img, border_size, 'left', darken=darken)
+    left_x = org_size + border_size
+    left_y = border_size
+    ## and the right
+    right_img = crop_side(img, border_size, 'right', darken=darken)
+    right_x = 0
+    right_y = border_size
+    ## and the top
+    top_img = crop_side(img, border_size, 'top', darken=darken)
+    top_x = border_size
+    top_y = org_size + border_size
+    ## and the bottom
+    bottom_img = crop_side(img, border_size, 'bottom', darken=darken)
+    bottom_x = border_size
+    bottom_y = 0
+
+    expanded_img.paste(tl_img, (tl_x, tl_y))
+    expanded_img.paste(br_img, (br_x, br_y))
+    expanded_img.paste(tr_img, (tr_x, tr_y))
+    expanded_img.paste(bl_img, (bl_x, bl_y))
+
+    expanded_img.paste(left_img, (left_x, left_y))
+    expanded_img.paste(right_img, (right_x, right_y))
+    expanded_img.paste(top_img, (top_x, top_y))
+    expanded_img.paste(bottom_img, (bottom_x, bottom_y))
+
+    return expanded_img
+
+def convert_binary_img_to_pil(binary_img):
+    pil_image = Image.open(BytesIO(binary_img))
+    return pil_image
+
+def convert_pil_img_to_binary(pil_img):
+    imgbuffer = BytesIO()
+    pil_img.save(imgbuffer, format='PNG')
+    binary_img = imgbuffer.getvalue()
+    return binary_img
+
+def convert_pil_img_to_base64_depr(pil_img):
+    imgbuffer = BytesIO()
+    pil_img.save(imgbuffer, format='PNG')
+    # Encode the bytes buffer to base64
+    img_base64 = base64.b64encode(imgbuffer.getvalue()).decode('utf-8')
+    return img_base64
+
+def convert_pil_img_to_base64(pil_img, force_rgb=True):
+    if pil_img.mode == 'RGBA':
+        pil_img = pil_img.convert('RGB')
+    buffered = BytesIO()
+    pil_img.save(buffered, format="PNG")
+    base64_str = base64.b64encode(buffered.getvalue()).decode("utf-8")
+    return base64_str
+
+def shift_image(img, x, y):
+    """shifts the pixels, wrapping around itself"""
+    np_img = np.array(img) ### convert to a numpy array, as we receive a PIL image.
+    np_img = np.roll(np_img, shift=x, axis=1)
+    np_img = np.roll(np_img, shift=y, axis=0)
+    return_img = Image.fromarray(np_img) ## convert numpy array back to PIL image.
+    return return_img
+
+def draw_center_cross_image(img=None, thickness_mult=1.0, blur_mult=1.0, offset_x=0, offset_y=0,
+                            x_start=0, x_end=0, y_start=0, y_end=0, boost=True):
+    if img:
+        width, height = img.size
+        img = Image.new('RGB', (width, height), (0, 0, 0))
+    else:
+        img = Image.new('RGB', (1280, 720), (0, 0, 0))
+
+    draw = ImageDraw.Draw(img, 'RGB')
+    width, height = img.size
+
+    ## now calculate the line thickness based on the resolution of the image
+    thickness = int((width / 25) * thickness_mult)
+    ## and calculate the blur_radius based on the thickness of the line.
+    blur_radius = thickness * 0.4 * blur_mult
+    print(f'blur radius is {blur_radius}')
+
+    ## now prepare some other values we will use
+    half_thickness = int(thickness / 2.0)
+    half_width = int(width / 2.0)
+    half_height = int(height / 2.0)
+    offset = thickness / 2 ## the offset of the line from the edge of the image.
+
+    ## first lets draw it vertically.
+    for i in range(thickness):
+        x1 = half_width - half_thickness + i + offset_x
+        y1 = y_start or (0 + offset)
+        x2 = half_width - half_thickness + i + offset_x
+        y2 = y_end or (height - offset)
+        draw.rectangle([(x1, y1), (x2, y2)], outline='white')
+
+    ## and now lets draw the horizontal cross bar.
+    for i in range(thickness):
+        x1 = x_start or (0 + offset)
+        y1 = half_height - half_thickness + i + offset_y
+        x2 = x_end or (width - offset)
+        y2 = half_height - half_thickness + i + offset_y
+        draw.rectangle([(x1, y1), (x2, y2)], outline='white')
+
+    img_blur = img.filter(ImageFilter.GaussianBlur(radius=blur_radius))
+    img_blur.show()
+
+    if boost:
+        ## finally lets lift up the whites a little that might have been affected by the blur.
+        lifted_img = ImageOps.autocontrast(img_blur, cutoff=2)
+        return lifted_img
+
+    return img_blur

--- a/modules/tiling/seamless_tiling.py
+++ b/modules/tiling/seamless_tiling.py
@@ -1,0 +1,50 @@
+from PIL import ImageOps, ImageEnhance, Image
+from modules.tiling.img_utils import convert_binary_img_to_pil, \
+                                    convert_pil_img_to_binary, \
+                                    expand_canvas_tiling
+
+def preprocess_expand_canvas_for_tile_image(img, border_size=128, darken=False, force_original_res=True):
+    ## first lets check the data type of the image, it could be binary or a PIL.Image...
+    if isinstance(img, bytes):
+        input_type = 'binary'
+        img = convert_binary_img_to_pil(img)
+    elif isinstance(img, Image.Image):
+        ### then it's a PIL.Image.
+        input_type = 'pil'
+
+    # Specify the path to your original image and the output path
+    width, height = img.size
+    org_size = width
+
+    expanded_img = expand_canvas_tiling(img, border_size=border_size, darken=darken)
+
+    if force_original_res:
+        expanded_img = expanded_img.resize((width, height), Image.Resampling.LANCZOS)
+        pass
+
+    ## finally if the input_type was binary, we need to convert the pil img back to binary
+    if input_type=='binary':
+        expanded_img = convert_pil_img_to_binary(expanded_img)
+
+    return expanded_img
+
+def postprocess_crop_canvas_back(img, border_size=128):
+    ## check if the incoming image is binary or pil
+    if isinstance(img, bytes):
+        input_type = 'binary'
+        img = convert_binary_img_to_pil(img)
+    elif isinstance(img, Image.Image):
+        input_type = 'pil'
+    ## get the image size
+    width, height = img.size
+    ## now crop back the image
+    cropped_img = img.crop((border_size, border_size, width - border_size, height - border_size))
+
+    ## if the input was binary, make sure to convert it back to binary
+    if input_type=='binary':
+        cropped_img = convert_pil_img_to_binary(cropped_img)
+
+    return cropped_img
+
+
+

--- a/predict.py
+++ b/predict.py
@@ -2,6 +2,16 @@
 from modules import timer
 from modules import initialize_util
 from modules import initialize
+from modules.tiling.seamless_tiling import preprocess_expand_canvas_for_tile_image, postprocess_crop_canvas_back
+from modules.tiling.img_utils import calculate_border_size, \
+                                    convert_pil_img_to_binary, \
+                                    convert_binary_img_to_pil, \
+                                    convert_pil_img_to_base64, \
+                                    shift_image, \
+                                    draw_center_cross_image
+from modules.debugging.debug_image import debug_tiling_image, \
+                                          expand_canvas_tiling, \
+                                          save_output_img
 from urllib.parse import urlparse
 from fastapi import FastAPI
 from io import BytesIO
@@ -29,24 +39,24 @@ Image.MAX_IMAGE_PIXELS = None
 class Predictor(BasePredictor):
     def setup(self) -> None:
         """Load the model into memory to make running multiple predictions efficient"""
-        
+
         os.environ['IGNORE_CMD_ARGS_ERRORS'] = '1'
-        
+
         startup_timer = timer.startup_timer
         startup_timer.record("launcher")
-        
+
         initialize.imports()
         initialize.check_versions()
         initialize.initialize()
-        
+
         app = FastAPI()
         initialize_util.setup_middleware(app)
-        
+
         from modules.api.api import Api
         from modules.call_queue import queue_lock
-        
+
         self.api = Api(app, queue_lock)
-        
+
         model_response = self.api.get_sd_models()
         print("Available checkpoints: ", str(model_response))
 
@@ -87,10 +97,10 @@ class Predictor(BasePredictor):
                         4,
                         8,
                         "4x-UltraSharp",
-                        1.1, 
-                        False, 
+                        1.1,
+                        False,
                         0,
-                        0.0, 
+                        0.0,
                         3,
                     ]
                 },
@@ -130,7 +140,7 @@ class Predictor(BasePredictor):
                 }
             }
         }
-        
+
         req = StableDiffusionImg2ImgProcessingAPI(**payload)
         self.api.img2imgapi(req)
 
@@ -171,13 +181,13 @@ class Predictor(BasePredictor):
 
     def calc_scale_factors(self, value):
         lst = []
-        while value >= 2: 
+        while value >= 2:
             lst.append(2)
-            value /= 2 
+            value /= 2
         if value > 1:
             lst.append(value)
         return lst
-    
+
     def predict(
         self,
         image: Path = Input(description="input image"),
@@ -245,6 +255,22 @@ class Predictor(BasePredictor):
             choices=['disabled', 'hands_only', 'image_and_hands'],
             default="disabled",
         ),
+        seamless_tiling: bool = Input(
+            description="Seamless tiling",
+            default=False,
+        ),
+        seamless_tiling_overlap_width: float = Input(
+            description="Size over overlap for tiling seam fix, default 1.0, value functions as multiplier",
+            default=1.0,
+        ),
+        seamless_tiling_overlap_blur: float = Input(
+            description="Size of the blur on the overlap for tiling seam fix, default 1.0, value functions as multiplier",
+            default=1.0,
+        ),
+        seamless_tiling_debug_mode: bool = Input(
+            description="If turned on, returns all the images in the seamless tiling process to allow for debugging",
+            default=True,
+        ),
         output_format: str = Input(
             description="Format of the output images",
             choices=["webp", "jpg", "png"],
@@ -254,27 +280,48 @@ class Predictor(BasePredictor):
         """Run a single prediction on the model"""
         print("Running prediction")
         start_time = time.time()
-        
+
+        outputs = [] ## init at the start so we can grab the initial image wrangling for debugging
+
         # checkpoint name changed bc hashing is deactivated so name is corrected here to old name to avoid breaking api calls
         if sd_model == "epicrealism_naturalSinRC1VAE.safetensors [84d76a0328]":
             sd_model = "epicrealism_naturalSinRC1VAE.safetensors"
         if sd_model == "juggernaut_reborn.safetensors [338b85bc4f]":
             sd_model = "juggernaut_reborn.safetensors"
-    
+
         if lora_links:
             lora_link = [link.strip() for link in lora_links.split(",")]
             for link in lora_link:
-                self.download_lora_weights(link) 
+                self.download_lora_weights(link)
 
         if custom_sd_model:
             path_to_custom_checkpoint = self.download_safetensors(custom_sd_model)
             sd_model = os.path.basename(path_to_custom_checkpoint)
             self.api.refresh_checkpoints()
-        
+
         image_file_path = image
 
         with open(image_file_path, "rb") as image_file:
             binary_image_data = image_file.read()
+
+        if seamless_tiling:
+            ## first lets save this initial image...
+            init_img = convert_binary_img_to_pil(binary_image_data)
+            ## now lets expand the canvas.
+            expanded_img = expand_canvas_tiling(init_img, div=8, darken=False)
+
+            ## now update the original binary image data.
+            binary_image_data = convert_pil_img_to_binary(expanded_img)
+
+            if seamless_tiling_debug_mode:
+                ## and here we save the outputs
+                out1 = save_output_img(init_img,
+                                      f"010_init_img.{output_format}",
+                                      info_text="1. initial image")
+                out2 = save_output_img(expanded_img,
+                                      f"020_expanded.{output_format}",
+                                      info_text="2. expanded canvas")
+                outputs += [out1, out2]
 
         if mask:
             with Image.open(image_file_path) as img:
@@ -286,12 +333,12 @@ class Predictor(BasePredictor):
             image = cv2.imdecode(image_np_array, cv2.IMREAD_UNCHANGED)
 
             height, width = image.shape[:2]
-            
+
             if height > width:
                 scaling_factor = downscaling_resolution / float(height)
             else:
                 scaling_factor = downscaling_resolution / float(width)
-            
+
             new_width = int(width * scaling_factor)
             new_height = int(height * scaling_factor)
 
@@ -311,7 +358,7 @@ class Predictor(BasePredictor):
 
                 cropped_hand_img_rgb = cv2.cvtColor(cropped_hand_img, cv2.COLOR_BGR2RGB)
                 cropped_hand_img_pil = Image.fromarray(cropped_hand_img_rgb)
-    
+
             else:
                 print("No hands detected")
                 return
@@ -323,98 +370,32 @@ class Predictor(BasePredictor):
         if scale_factor > 2:
             multipliers = self.calc_scale_factors(scale_factor)
             print("Upscale your image " + str(len(multipliers)) + " times")
-        
-        first_iteration = True
 
-        for multiplier in multipliers:
+        first_iteration = True
+        last_iteration = False
+
+        for i, multiplier in enumerate(multipliers):
             print("Upscaling with scale_factor: ", multiplier)
-            
+
             if not first_iteration:
                 creativity = creativity * 0.8
                 seed = seed +1
-                
+
             first_iteration = False
 
-            payload = {
-                "override_settings": {
-                    "sd_model_checkpoint": sd_model,
-                    "sd_vae": "vae-ft-mse-840000-ema-pruned.safetensors",
-                    "CLIP_stop_at_last_layers": 1,
-                },
-                "override_settings_restore_afterwards": False,
-                "init_images": [base64_image],
-                "prompt": prompt,
-                "negative_prompt": negative_prompt,
-                "steps": num_inference_steps,
-                "cfg_scale": dynamic,
-                "seed": seed,
-                "do_not_save_samples": True,
-                "sampler_name": scheduler,
-                "denoising_strength": creativity,
-                "alwayson_scripts": {
-                    "Tiled Diffusion": {
-                        "args": [
-                            True,
-                            "MultiDiffusion",
-                            True,
-                            True,
-                            1,
-                            1,
-                            tiling_width,
-                            tiling_height,
-                            4,
-                            8,
-                            "4x-UltraSharp",
-                            multiplier, 
-                            False, 
-                            0,
-                            0.0, 
-                            3,
-                        ]
-                    },
-                    "Tiled VAE": {
-                        "args": [
-                            True,
-                            2048,
-                            128,
-                            True,
-                            True,
-                            True,
-                            True,
-                        ]
-                    },
-                    "controlnet": {
-                        "args": [
-                            {
-                                "enabled": True,
-                                "module": "tile_resample",
-                                "model": "control_v11f1e_sd15_tile",
-                                "weight": resemblance,
-                                "image": base64_image,
-                                "resize_mode": 1,
-                                "lowvram": False,
-                                "downsample": 1.0,
-                                "guidance_start": 0.0,
-                                "guidance_end": 1.0,
-                                "control_mode": 1,
-                                "pixel_perfect": True,
-                                "threshold_a": 1,
-                                "threshold_b": 1,
-                                "save_detected_map": False,
-                                "processor_res": 512,
-                            }
-                        ]
-                    }
-                }
-            }
+            ## lets also determine whether this is the _last_ iteration
+            ## for our seamless tiling feature..
+            last_iteration = True if i==len(multipliers) - 1 else False
+
+            payload = get_clarity_upscaler_payload(sd_model, tiling_width, tiling_height, multiplier, base64_image,
+                                resemblance, prompt, negative_prompt, num_inference_steps, dynamic, seed, scheduler,
+                                creativity)
 
             req = self.StableDiffusionImg2ImgProcessingAPI(**payload)
             resp = self.api.img2imgapi(req)
             info = json.loads(resp.info)
 
             base64_image = resp.images[0]
-
-            outputs = []
 
             for i, image in enumerate(resp.images):
                 seed = info.get("all_seeds", [])[i] or "unknown_seed"
@@ -424,18 +405,18 @@ class Predictor(BasePredictor):
 
                 if handfix == "hands_only":
                     imageObject = insert_cropped_hand_into_image(binary_image_data_full_image, imageObject, hand_coords, cropped_hand_img_pil)
-    
+
                 if mask:
                     imageObject = imageObject.resize(original_resolution, Image.LANCZOS)
                     original_image = Image.open(image_file_path).resize(original_resolution, Image.LANCZOS)
                     mask_image = Image.open(mask).convert("L").resize(original_resolution, Image.LANCZOS)
-                    
+
                     blur_radius = 5
                     mask_image = mask_image.filter(ImageFilter.GaussianBlur(blur_radius))
                     combined_image = Image.composite(original_image, imageObject, mask_image)
 
                     imageObject = combined_image
-                
+
                 if sharpen > 0:
                     a = -sharpen / 10
                     b = 1 - 8 * a
@@ -443,7 +424,7 @@ class Predictor(BasePredictor):
                     kernel_filter = ImageFilter.Kernel((3, 3), kernel, scale=1, offset=0)
 
                     imageObject = imageObject.filter(kernel_filter)
-                
+
                 optimised_file_path = Path(f"{seed}-{uuid.uuid1()}.{output_format}")
 
                 if output_format in ["webp", "jpg"]:
@@ -455,7 +436,150 @@ class Predictor(BasePredictor):
                 else:
                     imageObject.save(optimised_file_path)
 
+                if seamless_tiling and last_iteration:
+                    print('--- starting seamless tiling process on the last upscale iteration')
+                    gen_bytes = BytesIO(base64.b64decode(image))
+                    upscaled_img = Image.open(gen_bytes)
+
+                    ## crop back
+                    width = upscaled_img.width
+                    height = upscaled_img.height
+                    border_size = int(width / 10)
+                    cropped_back = upscaled_img.crop((border_size, border_size, width - border_size, height - border_size))
+
+                    ## now lets create a final debug tile.
+                    debug_tiling_A = debug_tiling_image(cropped_back)
+
+                    ## now lets shift the pixels 50% to get the seam in the middle
+                    shift_x = cropped_back.width // 2
+                    shift_y = cropped_back.height // 2
+                    shifted_img_A = shift_image(cropped_back, shift_x, shift_y)
+                    shifted_img_A_base64 = convert_pil_img_to_base64(shifted_img_A)
+                    inpaint_mask_A_base64, inpaint_mask_A = get_seamless_tiling_mask(shifted_img_A_base64,
+                                                                            seamless_tiling_overlap_width,
+                                                                            seamless_tiling_overlap_blur,
+                                                                            )
+                    ## get payload to do API inpainting
+                    payload = get_clarity_upscaler_payload(sd_model, tiling_width, tiling_height, multiplier,
+                                                           shifted_img_A_base64,
+                                                           resemblance, prompt, negative_prompt, num_inference_steps,
+                                                           dynamic, seed, scheduler, creativity,
+                                                           seamfix_mask=inpaint_mask_A_base64)
+                    req = self.StableDiffusionImg2ImgProcessingAPI(**payload)
+                    resp = self.api.img2imgapi(req)
+                    info = json.loads(resp.info)
+
+                    ## now we have our resulting image
+                    base64_image = resp.images[0]
+                    gen_bytes = BytesIO(base64.b64decode(base64_image))
+                    seam_fix_A = Image.open(gen_bytes)
+
+                    ## we can shift the pixels back to their original place
+                    shiftback_img_A = shift_image(seam_fix_A, -shift_x, -shift_y)
+                    shiftback_img_A.save(optimised_file_path)  ### overwrite the final output with the shiftedback image
+
+                    ## now lets create a final debug tile.
+                    debug_tiling_B = debug_tiling_image(shiftback_img_A)
+
+                    ## here lets do one more pass, as our cross mask will have never repainted
+                    ## the outer edges of our image.. so we going to offset the pixels 33% and
+                    ## do another round of inpainting.
+                    shift_x = shiftback_img_A.width // 3
+                    shift_y = shiftback_img_A.height // 3
+                    shifted_img_B = shift_image(shiftback_img_A, shift_x, shift_y)
+                    shifted_img_B_base64 = convert_pil_img_to_base64(shifted_img_B)
+
+                    ## calculate how much to offset the inpaint mask at 33%
+                    fourth = (shifted_img_B.width // 4)
+                    third = (shifted_img_B.width // 3)
+                    fraction = (shifted_img_B.width // 20)
+                    offset_x =  (fourth + fourth) - (third + third)
+                    offset_y =  (fourth + fourth) - (third + third)
+
+                    ## now draw the offset cross image
+                    inpaint_mask_B_base64, inpaint_mask_B = get_seamless_tiling_mask(shifted_img_B_base64,
+                                                                            seamless_tiling_overlap_width,
+                                                                            seamless_tiling_overlap_blur * 1.2,
+                                                                            offset_x=offset_x,
+                                                                            offset_y=offset_y,
+                                                                            x_start=fourth+fourth+third-fraction,
+                                                                            x_end=fourth+fourth+third+fraction,
+                                                                            y_start=fourth+fourth+third-fraction,
+                                                                            y_end=fourth+fourth+third+fraction,
+                                                                            boost=False)
+
+                    ## now we can finally do our last inpainting call.
+                    ## let's drop the creativity way down, and push the resemblance up.
+                    payload = get_clarity_upscaler_payload(sd_model, tiling_width, tiling_height, multiplier,
+                                                           shifted_img_B_base64,
+                                                           1.0, prompt, negative_prompt, num_inference_steps,
+                                                           dynamic, seed, scheduler, 0.35,
+                                                           seamfix_mask=inpaint_mask_B_base64)
+
+                    req = self.StableDiffusionImg2ImgProcessingAPI(**payload)
+                    resp = self.api.img2imgapi(req)
+                    info = json.loads(resp.info)
+
+                    ## so here we should get our result..
+                    base64_image = resp.images[0]
+                    gen_bytes = BytesIO(base64.b64decode(base64_image))
+                    seam_fix_B = Image.open(gen_bytes)
+
+                    ## now lets shift the image back again
+                    shiftback_img_B = shift_image(seam_fix_B, -shift_x, -shift_y)
+                    shiftback_img_B.save(optimised_file_path)  ### overwrite the final output with the shiftedback image
+
+                    debug_tiling_C = debug_tiling_image(shiftback_img_B)
+
+                    output_tiling = expand_canvas_tiling(shiftback_img_B, div=1, darken=False)
+
+                    if seamless_tiling_debug_mode:
+                        out3 = save_output_img(upscaled_img,
+                                                  f"030_upscaled.{output_format}",
+                                                  info_text="3. upscaled (canvas expanded)")
+                        out4 = save_output_img(cropped_back,
+                                                  f"040_cropped_back.{output_format}",
+                                                  info_text="4. upscaled (cropped back)")
+                        out5 = save_output_img(debug_tiling_A,
+                                                  f'050_debug_tile_not_fixed.{output_format}',
+                                                  info_text="5. tiling debug (before fix)")
+                        out6 = save_output_img(shifted_img_A,
+                                                  f'060_shifted_center.{output_format}',
+                                                  info_text="6. center seam (shifted 50%)")
+                        out7 = save_output_img(inpaint_mask_A,
+                                                  f'070_inpaint_mask.{output_format}',
+                                                  '7. inpainting mask')
+                        out8 = save_output_img(seam_fix_A,
+                                                  f'080_inpainted_seam_fix.{output_format}',
+                                                  info_text="8. seam fix 1")
+                        out9 = save_output_img(shiftback_img_A,
+                                                  f'090_shifted_back_fix.{output_format}',
+                                                  info_text="9. upscaled (shifted back 50%)")
+                        out10 = save_output_img(debug_tiling_B,
+                                                  f'100_debug_tile.{output_format}',
+                                                  info_text="10. tiling debug (after 1st fix)")
+                        out11 = save_output_img(shifted_img_B,
+                                                  f'110_shift_30pct.{output_format}',
+                                                  info_text="11. shift pixels 30%")
+                        out12 = save_output_img(inpaint_mask_B,
+                                                  f'120_inpaint_mask.{output_format}',
+                                                  '12. inpainting mask')
+                        out13 = save_output_img(seam_fix_B,
+                                                  f'130_inpainted_seam_fix.{output_format}',
+                                                  info_text="13. seam fix 2 ")
+                        out14 = save_output_img(shiftback_img_B,
+                                                  f"140_shifted_back_fix.{output_format}",
+                                                  info_text="14. upscaled (shifted back 30%)")
+                        out15 = save_output_img(debug_tiling_C,
+                                                  f'150_debug_tile.{output_format}',
+                                                  info_text="15. tiling debug (after 2nd fix)")
+                        out16 = save_output_img(output_tiling,
+                                                  f'160_resulting_tile.{output_format}',
+                                                  info_text="16. tiling result")
+                        outputs += [out3, out4, out5, out6, out7, out8, out9, out10, out11, out12, out13, out14, out15, out16]
+
                 outputs.append(optimised_file_path)
+
 
         if custom_sd_model:
             os.remove(path_to_custom_checkpoint)
@@ -463,4 +587,144 @@ class Predictor(BasePredictor):
 
         print(f"Prediction took {round(time.time() - start_time,2)} seconds")
         return outputs
-    
+
+def get_seamless_tiling_mask(base64_image, width_mult, blur_mult,
+                            offset_x=0, offset_y=0,
+                            x_start=0, x_end=0, y_start=0, y_end=0,
+                            boost=True):
+    gen_bytes = BytesIO(base64.b64decode(base64_image))
+    img = Image.open(gen_bytes)
+    mask_pil = draw_center_cross_image(img, thickness_mult=width_mult, blur_mult=blur_mult,
+                                    offset_x=offset_x, offset_y=offset_y,
+                                    x_start=x_start, x_end=x_end, y_start=y_start, y_end=y_end,
+                                    boost=boost)
+    mask_base64 = convert_pil_img_to_base64(mask_pil)
+
+    return mask_base64, mask_pil
+
+def get_clarity_upscaler_payload(sd_model,
+                                tiling_width,
+                                tiling_height,
+                                multiplier,
+                                base64_image,
+                                resemblance,
+                                prompt,
+                                negative_prompt,
+                                num_inference_steps,
+                                dynamic,
+                                seed,
+                                scheduler,
+                                creativity,
+                                seamfix_mask=None):
+    if seamfix_mask:
+        multiplier = 1.0 ## set the multiplier to 1 as we're not upscaling in this round.
+
+    override_settings = {
+        "sd_model_checkpoint": sd_model,
+        "sd_vae": "vae-ft-mse-840000-ema-pruned.safetensors",
+        "CLIP_stop_at_last_layers": 1,
+    }
+    alwayson_scripts = {
+        "Tiled Diffusion": {"args": get_tiled_diffusion_args(tiling_width, tiling_height, multiplier)},
+        "Tiled VAE": {"args": get_tiled_vae_args()},
+        "controlnet": {"args": get_controlnet_args(base64_image, resemblance)}
+    }
+
+    if seamfix_mask:
+        payload_dict = {
+            "override_settings": override_settings,
+            "override_settings_restore_afterwards": False,
+            "init_images": [base64_image],
+            "mask": seamfix_mask,
+            "mask_blur": 0,
+            "inpainting_fill": 1,  ## [fill, original, latent noise, latent nothing]
+            "inpaint_full_res": True,
+            "inpaint_full_res_padding": 0,
+            "inpainting_mask_invert": 0,
+            "include_init_images": True,
+            "prompt": prompt,
+            "negative_prompt": negative_prompt,
+            "steps": num_inference_steps,
+            "cfg_scale": dynamic,
+            "seed": seed,
+            "tiling": True,
+            "do_not_save_samples": True,
+            "sampler_name": scheduler,
+            "denoising_strength": creativity,
+            "alwayson_scripts": alwayson_scripts,
+        }
+    else:
+        payload_dict = {
+            "override_settings": override_settings,
+            "override_settings_restore_afterwards": False,
+            "init_images": [base64_image],
+            "prompt": prompt,
+            "negative_prompt": negative_prompt,
+            "steps": num_inference_steps,
+            "cfg_scale": dynamic,
+            "seed": seed,
+            "tiling": True,
+            "do_not_save_samples": True,
+            "sampler_name": scheduler,
+            "denoising_strength": creativity,
+            "alwayson_scripts": alwayson_scripts,
+        }
+
+    return payload_dict
+
+def get_tiled_diffusion_args(tiling_width, tiling_height, multiplier):
+    arg_list = [
+        True,
+        "MultiDiffusion",
+        True,
+        True,
+        1,
+        1,
+        tiling_width,
+        tiling_height,
+        4,
+        8,
+        "4x-UltraSharp",
+        multiplier,
+        False,
+        0,
+        0.0,
+        3,
+    ]
+
+    return arg_list
+
+def get_tiled_vae_args():
+    arg_list =  [
+        True,
+        2048,
+        128,
+        True,
+        True,
+        True,
+        True,
+    ]
+    return arg_list
+
+def get_controlnet_args(base64_image, resemblance):
+    arg_dict = {
+        "enabled": True,
+        "module": "tile_resample",
+        "model": "control_v11f1e_sd15_tile",
+        "weight": resemblance,
+        "image": base64_image,
+        "resize_mode": 1,
+        "lowvram": False,
+        "downsample": 1.0,
+        "guidance_start": 0.0,
+        "guidance_end": 1.0,
+        "control_mode": 1,
+        "pixel_perfect": True,
+        "threshold_a": 1,
+        "threshold_b": 1,
+        "save_detected_map": False,
+        "processor_res": 512,
+    }
+    arg_list = [arg_dict]
+
+    return arg_list


### PR DESCRIPTION
Adds the option to maintain seamless tile-able textures during upscale. 

Exposes 4 new parameters on the replicate cog:
- seamless_tiling
- seamless_tiling_overlap_width
- seamless_tiling_overlap_blur
- seamless_tiling_debug_mode

with the debug mode turned on the cog returns images for each intermediary step used to generate the seamless tiling. Can be useful for debugging the actual size of the overlap_width or overlap_blur.