### PR TITLE
fix: update CLIP module path to match correct Python version (3.10.15)

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -22,5 +22,5 @@ build:
     - git config --global --add safe.directory /src/extensions/multidiffusion-upscaler-for-automatic1111
     - git clone https://github.com/philz1337x/stable-diffusion-webui-cog-init /stable-diffusion-webui
     - python /stable-diffusion-webui/init_env.py --skip-torch-cuda-test
-    - sed -i 's/from pkg_resources import packaging/import packaging/g' /root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/clip/clip.py
+    - sed -i 's/from pkg_resources import packaging/import packaging/g' /root/.pyenv/versions/3.10.15/lib/python3.10/site-packages/clip/clip.py
 predict: "predict.py:Predictor"


### PR DESCRIPTION
## Bug Fix: CLIP Module Path Update

### Issue
The Docker build was failing with the following error:
```sed: can't read /root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/clip/clip.py: No such file or directory```

This occurred because the `sed` command in `cog.yaml` was trying to modify the CLIP module in Python 3.10.4's site-packages directory, but the module was actually installed under Python 3.10.15 despite the python version being specified as 3.10.4 in cog.yaml.

### Changes
- Updated the Python path in the `sed` command from:

 ` - sed -i 's/from pkg_resources import packaging/import packaging/g' /root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/clip/clip.py`
 
 to:
 
` - sed -i 's/from pkg_resources import packaging/import packaging/g' /root/.pyenv/versions/3.10.15/lib/python3.10/site-packages/clip/clip.py`